### PR TITLE
Added support for pinentry

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -9,6 +9,7 @@ fn = -*-terminus-medium-*-*-*-16-*-*-*-*-*-*-*
 # b =  (just set to empty value and menu will appear at the bottom
 # m = number of monitor to display on
 # p = Custom Prompt for the networks menu
+# pinentry = Pinentry command
 
 [editor]
 terminal = urxvtc

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -276,8 +276,18 @@ def get_passphrase():
     Returns: string
 
     """
-    return Popen(dmenu_cmd(0, "Passphrase"),
-                 stdin=PIPE, stdout=PIPE).communicate()[0].decode()
+
+    conf = configparser.ConfigParser()
+    conf.read(expanduser("~/.config/networkmanager-dmenu/config.ini"))
+    pinentry = conf.get("dmenu","pinentry")
+    if pinentry:
+        s = Popen(pinentry, stdout=PIPE, stdin=PIPE)
+        out = s.communicate(input=b'setdesc Get network password\ngetpin\n')[0]
+        pin = out.decode().split("\n")[2].split("D ")[1]
+        return pin
+    else:
+        return Popen(dmenu_cmd(0, "Passphrase"),
+                    stdin=PIPE, stdout=PIPE).communicate()[0].decode()
 
 
 def set_new_connection(ssid, pw):


### PR DESCRIPTION
Using rofi the passwords are typed in clear text. I found it partially
annoying and decided to add an option to use pinentry.

:shipit: