### PR TITLE
Replace Popen calls to nmcli with api calls to the Python GI API

### DIFF
--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -174,32 +174,32 @@ class Action(object):
             self.f(*self.args)
 
 
-def process_ap(ap):
-    is_existing = len(ap.filter_connections(conns)) > 0
-    if is_existing:
-        toggle_existing(ssid_to_utf8(ap))
+def process_ap(ap, is_active):
+    if is_active:
+        client.deactivate_connection_async(ap)
     else:
-        if ap_security(ap) != "--":
-            password = get_passphrase()
+        con = ap.filter_connections(conns)
+        if len(con) > 1:
+            raise ValueError("There are multiple connections possible")
+
+        if len(con) == 1:
+            client.activate_connection_async(con[0])
         else:
-            password = ""
-        set_new_connection(ssid_to_utf8(ap), password)
+            if ap_security(ap) != "--":
+                password = get_passphrase()
+            else:
+                password = ""
+            set_new_connection(ssid_to_utf8(ap), password)
 
 
-def process_vpn(vpn, activate):
-    print("Processing VPN: %s" % vpn.get_id())
+def process_vpngsm(con, activate):
     if activate:
-        client.activate_connection_async(vpn)
+        client.activate_connection_async(con)
     else:
-        client.deactivate_connection_async(vpn)
+        client.deactivate_connection_async(con)
 
 
-def process_gsm(gsm):
-    print("Processing GSM: %s" % gsm.get_id())
-    toggle_existing(gsm.get_id())
-
-
-def create_ap_actions(aps, active_ap):
+def create_ap_actions(aps, active_ap, active_connection):
     active_ap_bssid = active_ap.get_bssid() if active_ap is not None else ""
 
     names = [ssid_to_utf8(ap) for ap in aps]
@@ -211,41 +211,52 @@ def create_ap_actions(aps, active_ap):
 
     for ap, name, sec in zip(aps, names, secs):
         bars = NM.utils_wifi_strength_bars(ap.get_strength())
-        active_flag = "**" if ap.get_bssid() == active_ap_bssid else "  "
-        ap_actions.append(Action("{} {:<{}s}  {:<{}s}  {}".format(active_flag,
-                          name, max_len_name, sec, max_len_sec, bars),
-                          process_ap, ap))
+        is_active = ap.get_bssid() == active_ap_bssid
+        active_flag = "**" if is_active else "  "
+        action_name = "{} {:<{}s}  {:<{}s}  {}".format(active_flag, name,
+                                                       max_len_name, sec,
+                                                       max_len_sec, bars)
+        if is_active:
+            ap_actions.append(Action(action_name, process_ap,
+                                     [active_connection, True]))
+        else:
+            ap_actions.append(Action(action_name, process_ap, [ap, False]))
     return ap_actions
 
 
 def create_vpn_actions(vpns, active):
-    active_vpn_ids = [a.get_id() for a in active if a.get_vpn()]
-    actions = []
-    for vpn in vpns:
-        is_active = vpn.get_id() in active_vpn_ids
-        active_flag = "**" if is_active else "  "
-        action_name = "{} {}:VPN".format(active_flag, vpn.get_id())
-        if is_active:
-            active_connection = [a for a in active
-                                 if a.get_id() == vpn.get_id()]
-            assert len(active_connection) == 1
-            active_connection = active_connection[0]
-            actions.append(Action(action_name, process_vpn,
-                                  [active_connection, False]))
-        else:
-            actions.append(Action(action_name, process_vpn, [vpn, True]))
-    return actions
+    active_vpns = list(filter(lambda a: a.get_vpn(), active))
+    return _create_vpngsm_actions(vpns, active_vpns, "VPN")
 
 
 # TODO: Test this
 def create_gsm_actions(gsms, active):
-    active_gsm_ids = [a.get_id() for a in active if
-                      a.get_connection().is_type(NM.SETTING_GSM_SETTING_NAME)]
-    active_flags = ["**" if (gsm.get_id() in active_gsm_ids) else
-                    "  " for gsm in gsms]
-    return [Action("{} {}:GSM".format(active_flag, gsm.get_id()),
-                   process_gsm, gsm) for active_flag, gsm in
-            zip(active_flags, gsms)]
+    active_gsms = list(filter(lambda a: a.get_connection()
+                              .is_type(NM.SETTING_GSM_SETTING_NAME), active))
+    return _create_vpngsm_actions(gsms, active_gsms, "GSM")
+
+
+def _create_vpngsm_actions(cons, active_cons, label):
+    active_con_ids = [a.get_id() for a in active_cons]
+    actions = []
+    for con in cons:
+        is_active = con.get_id() in active_con_ids
+        active_flag = "**" if is_active else "  "
+        action_name = "{} {}:{}".format(active_flag, con.get_id(), label)
+        if is_active:
+            active_connection = [a for a in active_cons
+                                 if a.get_id() == con.get_id()]
+            if len(active_connection) != 1:
+                raise ValueError("Multiple active connections match"
+                                 " the connection: %s" % con.get_id())
+            active_connection = active_connection[0]
+
+            actions.append(Action(action_name, process_vpngsm,
+                                  [active_connection, False]))
+        else:
+            actions.append(Action(action_name, process_vpngsm,
+                                  [con, True]))
+    return actions
 
 
 def get_selection(client, aps, vpns, gsms, others):
@@ -282,24 +293,6 @@ def get_selection(client, aps, vpns, gsms, others):
                          aps + vpns + gsms + others))
     assert len(action) == 1, "Selection was ambiguous: %s" % str(sel)
     return action[0]
-
-
-def toggle_existing(conn):
-    """Get conn status, then toggle connection up or down if it's not
-    'activated'
-
-    Args: conn - string
-
-    """
-    conn_status = ["nmcli", "-t", "-f", "GENERAL.STATE",
-                   "connection", "show", conn]
-    res = Popen(conn_status, stdout=PIPE, env=ENV).communicate()[0]
-    if 'activated' not in res.decode(ENC):
-        updown = 'up'
-    else:
-        updown = 'down'
-    conn_string = ["nmcli", "connection", updown, "id", conn]
-    Popen(conn_string, stdout=PIPE, env=ENV).communicate()
 
 
 def toggle_networking(enable):
@@ -397,17 +390,24 @@ def set_new_connection(ssid, pw):
 
 
 def run():
+    active = client.get_active_connections()
+
     adapter = choose_adapter(client)
 
     if adapter:
         aps = sorted(adapter.get_access_points(),
                      key=lambda a: a.get_strength(), reverse=True)
         active_ap = adapter.get_active_access_point()
-        ap_actions = create_ap_actions(aps, active_ap)
+        active_ap_con = list(filter(lambda con: con.get_connection_type() ==
+                                    NM.SETTING_WIRELESS_SETTING_NAME, active))
+        print(active_ap_con)
+        if len(active_ap_con) > 1:
+            raise ValueError("Multiple connections match"
+                             " the wireless connection")
+        active_ap_con = active_ap_con[0] if active_ap_con else None
+        ap_actions = create_ap_actions(aps, active_ap, active_ap_con)
     else:
         ap_actions = []
-
-    active = client.get_active_connections()
 
     vpns = list(filter(lambda c: c.is_type(NM.SETTING_VPN_SETTING_NAME),
                        conns))

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -86,7 +86,9 @@ def choose_adapter(client):
     """
     devices = client.get_devices()
     devices = list(filter(lambda d: d.get_device_type() == NM.DeviceType.WIFI, devices))
-    if len(devices) <= 1:
+    if len(devices) == 0:
+        return None
+    elif len(devices) == 1:
         return devices[0]
     device_names = "\n".join([d.get_iface() for d in devices]).encode(ENC)
     sel = Popen(dmenu_cmd(len(devices), "CHOOSE ADAPTER:"),
@@ -229,7 +231,7 @@ def create_gsm_actions(gsms, active):
 
 
 
-def get_selection(client, adapter, aps, vpns, gsms, others):
+def get_selection(client, aps, vpns, gsms, others):
     """Combine the arg lists and send to dmenu for selection.
     Also executes the associated action.
 
@@ -243,7 +245,9 @@ def get_selection(client, adapter, aps, vpns, gsms, others):
     formated_gsms = [str(gsm) for gsm in gsms]
     formated_others = [str(other) for other in others]
 
-    inp = formated_aps + [""]
+    inp = []
+    if formated_aps:
+        inp += formated_aps + [""]
     if vpns:
         inp += formated_vpns + [""]
     if gsms:
@@ -376,22 +380,25 @@ def set_new_connection(ssid, pw):
 
 def run():
     adapter = choose_adapter(client)
-
     conns = client.get_connections()
+
+    if adapter:
+        aps = sorted(adapter.get_access_points(),
+                     key=lambda a: a.get_strength(), reverse=True) active_ap = adapter.get_active_access_point()
+        ap_actions = create_ap_actions(aps, active_ap, conns)
+    else:
+        ap_actions = []
+
+    active = client.get_active_connections()
 
     vpns = list(filter(lambda c: c.is_type(NM.SETTING_VPN_SETTING_NAME), conns))
     gsms = list(filter(lambda c: c.is_type(NM.SETTING_GSM_SETTING_NAME), conns))
 
-    aps = sorted(adapter.get_access_points(), key=lambda a: a.get_strength(), reverse=True)
-    other_actions = create_other_actions(client)
-
-    active = client.get_active_connections()
-    active_ap = adapter.get_active_access_point()
-
-    ap_actions = create_ap_actions(aps, active_ap, conns)
     vpn_actions = create_vpn_actions(vpns, active)
     gsm_actions = create_gsm_actions(gsms, active)
-    sel = get_selection(client, adapter, ap_actions, vpn_actions,
+    other_actions = create_other_actions(client)
+
+    sel = get_selection(client, ap_actions, vpn_actions,
                         gsm_actions, other_actions)
     sel()
 
@@ -399,4 +406,4 @@ def run():
 if __name__ == '__main__':
     run()
 
-# vim: set et :
+# vim: set et ts=4 sw=4 :

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# encoding:utf8
 """NetworkManager command line dmenu script.
 
 To add new connections or enable/disable networking requires policykit
@@ -18,6 +19,11 @@ import shlex
 import sys
 from os.path import expanduser
 from subprocess import Popen, PIPE
+
+import gi
+gi.require_version('NM', '1.0')
+from gi.repository import NM
+
 try:
     import configparser as configparser
 except ImportError:
@@ -27,6 +33,7 @@ ENV = os.environ.copy()
 ENV['LC_ALL'] = 'C'
 ENC = locale.getpreferredencoding()
 
+client = NM.Client.new(None)
 
 def dmenu_cmd(num_lines, prompt="Networks"):
     """Parse config.ini if it exists and add options to the dmenu command
@@ -73,183 +80,187 @@ def dmenu_cmd(num_lines, prompt="Networks"):
     return res
 
 
-def choose_adapter():
+def choose_adapter(client):
     """If there is more than one wifi adapter installed, ask which one to use
 
     """
-    adps = ["nmcli", "device", "status"]
-    a = Popen(adps, stdout=PIPE,
-              env=ENV).communicate()[0].decode(ENC).split('\n')
-    all_adps = [i.split()[0] for i in a if 'wifi' in i]
-    if len(all_adps) <= 1:
-        return all_adps[0].strip()
-    all_adps_bytes = "\n".join(all_adps).encode(ENC)
-    sel = Popen(dmenu_cmd(len(all_adps), "CHOOSE ADAPTER:"),
+    devices = client.get_devices()
+    devices = list(filter(lambda d: d.get_device_type() == NM.DeviceType.WIFI, devices))
+    if len(devices) <= 1:
+        return devices[0]
+    device_names = "\n".join([d.get_iface() for d in devices]).encode(ENC)
+    sel = Popen(dmenu_cmd(len(devices), "CHOOSE ADAPTER:"),
                 stdin=PIPE,
                 stdout=PIPE,
-                env=ENV).communicate(input=all_adps_bytes)[0].decode(ENC)
+                env=ENV).communicate(input=device_names)[0].decode(ENC)
     if not sel.strip():
         sys.exit()
-    return sel.strip()
+    devices = filter(lambda d: d.get_iface() == sel.strip(), devices)
+    assert len(devices) == 1
+    return devices[0]
 
 
-def current_conns():
-    """Get list of current NetworkManager connections (ssid:security)
-
-    Returns: list of strings: ['firecat4153:WPA2', 'firecat4153x:WEP'...]
-
-    """
-    conns = ["nmcli", "-t", "-f", "name,type", "connection"]
-    return Popen(conns, stdout=PIPE).communicate()[0].decode(ENC).split('\n')
-
-
-def current_ssids(adapter):
-    """Get list of current SSIDs seen by NetworkManager and order by signal
-    strength
-
-    Returns: list -
-        ["firecat4153:WPA2","firecat4153-guest:", "firecat4153x:WPA2"]
-
-    """
-    scan = ["nmcli", "-f", "in-use,ssid,security,bars,signal", "device",
-            "wifi", "list", "ifname", adapter]
-    res = Popen(scan,
-                stdout=PIPE).communicate()[0].decode(ENC).split("\n")[2:-1]
-    res = [i.rstrip().rsplit(' ', 1) for i in res]
-    res = sorted(res, key=lambda x: int(x[1]), reverse=True)
-    res = unique_ssid(res)
-    return [i[0].replace("'", "").rstrip() for i in res]
-
-
-def unique_ssid(conns):
-    """Filters the list of ids, so that duplicate ids will only show the one
-    with the greatest strength. The list of ssids is already sorted by strength
-    so this just deletes any duplicates after the first item.
-
-    """
-    ssids = []
-    cons = []
-    for conn in conns:
-        s = conn[0].rstrip().rsplit(' ', 1)[0].strip()
-        i = conns.index(conn)
-        if s not in ssids:
-            ssids.append(s)
-            cons.append(conns[i])
-    return cons
-
-
-def vpn_connections(conns):
-    """Parse list of current connections for VPNs
-
-    Args: conns - ['ssid:security', 'firecat4153:WPA2', ...]
-    Returns: list of VPN connection names ['pia_us_west',...]
-
-    """
-    conns = [i.split(':') for i in conns if i]
-    return [i[0] for i in conns if i and 'vpn' in i[1]]
-
-
-def gsm_connections(conns):
-    """Parse list of current connections for GSM
-
-    Args: conns - ['ssid:security', 'firecat4153:WPA2', ...]
-    Returns: list of GSM connection names ['some_provider',...]
-
-    """
-    conns = [i.split(':') for i in conns if i]
-    return [i[0] for i in conns if i and 'gsm' in i[1]]
-
-
-def get_network_status():
-    """Get current status of networking
-
-    Returns: string 'Enable' or 'Disable',
-
-    """
-    stat = ["nmcli", "networking"]
-    res = Popen(stat, stdout=PIPE, env=ENV).communicate()[0]
-    if 'enabled' in res.decode(ENC):
-        return 'Disable'
-    else:
-        return 'Enable'
-
-
-def get_wifi_status():
-    """Get current status of Wifi
-
-    Returns: string 'Enable' or 'Disable',
-
-    """
-    stat = ["nmcli", "r", "wifi"]
-    res = Popen(stat, stdout=PIPE, env=ENV).communicate()[0]
-    if 'enabled' in res.decode(ENC):
-        return 'Disable'
-    else:
-        return 'Enable'
-
-
-def get_active_connections():
-    """Get currently active connections
-
-    Returns: list of strings
-
-    """
-    status = ["nmcli", "-t", "-f", "name", "connection",
-              "show", "--active"]
-    active = Popen(status, stdout=PIPE).communicate()[0]
-    active = active.decode(ENC).split('\n')
-    del active[-1]
-    return active
-
-
-def mark_active(conns, active):
-    """Given a list of connections, mark currently active connections
-
-    Args: conns - list of strings
-    Returns: list of strings (active prepended with a '**')
-
-    """
-    conn_t = [i.rsplit(":", 1)[0] for i in conns]
-    act = [i for i in conn_t if i and i in active]
-    for i, conn in enumerate(conn_t):
-        if conn in act:
-            conns[i] = "**{}".format(conns[i])
-    return conns
-
-
-def other_actions():
+def create_other_actions(client):
     """Return list of other actions that can be taken
 
     """
-    return ["{} Wifi".format(get_wifi_status()),
-            "{} Networking".format(get_network_status()),
-            "Launch Connection Manager"]
+    networking_enabled = client.networking_get_enabled()
+    networking_action = "Disable" if networking_enabled else "Enable"
+    wifi_enabled = client.wireless_get_enabled()
+    wifi_action = "Disable" if wifi_enabled else "Enable"
+    return [Action("{} Wifi".format(wifi_action), toggle_wifi, not wifi_enabled),
+            Action("{} Networking".format(networking_action), toggle_networking, not networking_enabled),
+            Action("Launch Connection Manager", launch_connection_editor, None)]
 
 
-def get_selection(ssids, vpns, gsms, other):
+# copied from https://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/examples/python/gi/show-wifi-networks.py
+def ssid_to_utf8(ap):
+    ssid = ap.get_ssid()
+    if not ssid:
+        return ""
+    return NM.utils_ssid_to_utf8(ssid.get_data())
+
+
+# copied from https://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/examples/python/gi/show-wifi-networks.py
+def ap_security(ap):
+    flags = ap.get_flags()
+    wpa_flags = ap.get_wpa_flags()
+    rsn_flags = ap.get_rsn_flags()
+    str = ""
+    if ((flags & getattr(NM, '80211ApFlags').PRIVACY) and
+        (wpa_flags == 0) and (rsn_flags == 0)):
+        str = str  + " WEP"
+    if wpa_flags != 0:
+        str = str + " WPA1"
+    if rsn_flags != 0:
+        str = str + " WPA2"
+    if ((wpa_flags & getattr(NM, '80211ApSecurityFlags').KEY_MGMT_802_1X) or
+        (rsn_flags & getattr(NM, '80211ApSecurityFlags').KEY_MGMT_802_1X)):
+        str = str + " 802.1X"
+
+    # If there is no security use "--"
+    if str == "":
+        str = "--"
+    return str.lstrip()
+
+
+class Action(object):
+    def __init__(self,
+                 name,
+                 f,
+                 args,
+                 ):
+        self.name = name
+        self.f = f
+        if args is None:
+            self.args = None
+        elif isinstance(args, list):
+            self.args = args
+        else:
+            self.args = [args]
+
+    def __str__(self):
+        return self.name
+
+    def __call__(self):
+        if self.args is None:
+            self.f()
+        else:
+            self.f(*self.args)
+
+
+def process_ap(ap, existing):
+    if existing:
+        toggle_existing(ssid_to_utf8(ap))
+    else:
+        if ap_security(ap) != "--":
+            password = get_passphrase()
+        else:
+            password = ""
+        set_new_connection(ssid_to_utf8(ap), password)
+
+def process_vpn(vpn, activate):
+    print("Processing VPN: %s" % vpn.get_id())
+    if activate:
+        client.activate_connection_async(vpn)
+    else:
+        client.deactivate_connection_async(vpn)
+
+
+def process_gsm(gsm):
+    print("Processing GSM: %s" % gsm.get_id())
+    toggle_existing(gsm.get_id())
+
+
+def create_ap_actions(aps, active_ap, existing_connections):
+    names = [ssid_to_utf8(ap) for ap in aps]
+    max_len_name = max([len(name) for name in names])
+    secs = [ap_security(ap) for ap in aps]
+    max_len_sec = max([len(sec) for sec in secs])
+    bars = [NM.utils_wifi_strength_bars(ap.get_strength()) for ap in aps]
+    active_ap_bssid = active_ap.get_bssid() if active_ap is not None else ""
+    active_flags = ["**" if ap.get_bssid() == active_ap_bssid else "  " for ap in aps]
+    existing_conn_names = [conn.get_id() for conn in existing_connections]
+    is_existing = [len(ap.filter_connections(existing_connections)) > 0 for ap in aps]
+    return [Action("{} {:<{}s}  {:<{}s}  {}".format(active_flag, name, max_len_name, sec, max_len_sec, bar), process_ap, [ap, exists]) for ap, active_flag, name, sec, bar, exists in zip(aps, active_flags, names, secs, bars, is_existing)]
+
+
+def create_vpn_actions(vpns, active):
+    active_vpn_ids = [a.get_id() for a in active if a.get_vpn()]
+    actions = []
+    for vpn in vpns:
+        is_active = vpn.get_id() in active_vpn_ids
+        active_flag = "**" if is_active else "  "
+        action_name = "{} {}:VPN".format(active_flag, vpn.get_id())
+        if is_active:
+            active_connection = [a for a in active if a.get_id() == vpn.get_id()]
+            assert len(active_connection) == 1
+            active_connection = active_connection[0]
+            actions.append(Action(action_name, process_vpn, [active_connection, False]))
+        else:
+            actions.append(Action(action_name, process_vpn, [vpn, True]))
+    return actions
+
+# TODO: Test this
+def create_gsm_actions(gsms, active):
+    active_gsm_ids = [a.get_id() for a in active if a.get_connection().is_type(NM.SETTING_GSM_SETTING_NAME)]
+    active_flags = ["**" if (gsm.get_id() in active_vpn_ids) else "  " for gsm in gsms]
+    return [Action("{} {}:GSM".format(active_flag, gsm.get_id()), process_gsm, gsm) for active_flag, gsm in zip(active_flags, gsms)]
+
+
+
+def get_selection(client, adapter, aps, vpns, gsms, others):
     """Combine the arg lists and send to dmenu for selection.
+    Also executes the associated action.
 
-    Args: args - ssids: list of strings
-                 vpns: list of strings
-                 gsms: list of strings
-                 other: list of strings
-    Returns: selection (string)
-
+    Args: args - aps: list of Actions
+                 vpns: list of Actions
+                 gsms: list of Actions
+                 others: list of Actions
     """
-    active = get_active_connections()
-    vpns = ["{}:VPN".format(i) for i in vpns]
-    vpns = mark_active(vpns, active) + [""] if vpns else []
-    gsms = ["{}:GSM".format(i) for i in gsms]
-    gsms = mark_active(gsms, active) + [""] if gsms else []
-    inp = ssids + [""] + vpns + gsms + other
-    inp_bytes = "\n".join(inp).encode(ENC)
+    formated_aps = [str(ap) for ap in aps]
+    formated_vpns = [str(vpn) for vpn in vpns]
+    formated_gsms = [str(gsm) for gsm in gsms]
+    formated_others = [str(other) for other in others]
+
+    inp = formated_aps + [""]
+    if vpns:
+        inp += formated_vpns + [""]
+    if gsms:
+        inp += formated_gsms + [""]
+    inp += formated_others
+
+    inp_bytes = "\n".join([str(i) for i in inp]).encode(ENC)
     sel = Popen(dmenu_cmd(len(inp)),
                 stdin=PIPE,
-                stdout=PIPE).communicate(input=inp_bytes)[0].decode(ENC)
+                stdout=PIPE, env=ENV).communicate(input=inp_bytes)[0].decode(ENC)
+
     if not sel.rstrip():
         sys.exit()
-    return sel.rstrip()
 
+    action = list(filter(lambda x: str(x) == sel.rstrip(), aps + vpns + gsms + others))
+    assert len(action) == 1
+    return action[0]
 
 def toggle_existing(conn):
     """Get conn status, then toggle connection up or down if it's not
@@ -269,32 +280,22 @@ def toggle_existing(conn):
     Popen(conn_string, stdout=PIPE, env=ENV).communicate()
 
 
-def toggle_networking(sel):
+def toggle_networking(enable):
     """Enable/disable networking
 
-    Args: sel - string ('Enable Networking' or 'Disable Networking')
+    Args: enable - boolean
 
     """
-    if sel.startswith('Enable'):
-        updown = 'on'
-    else:
-        updown = 'off'
-    net = ["nmcli", "networking", updown]
-    Popen(net, stdout=PIPE, env=ENV).communicate()
+    client.networking_set_enabled(enable)
 
 
-def toggle_wifi(sel):
+def toggle_wifi(enable):
     """Enable/disable Wifi
 
-    Args: sel - string ('Enable Wifi' or 'Disable Wifi')
+    Args: enable - boolean
 
     """
-    if sel.startswith('Enable'):
-        updown = 'on'
-    else:
-        updown = 'off'
-    net = ["nmcli", "r", "wifi", updown]
-    Popen(net, stdout=PIPE, env=ENV).communicate()
+    client.wireless_set_enabled(enable)
 
 
 def launch_connection_editor():
@@ -374,46 +375,28 @@ def set_new_connection(ssid, pw):
 
 
 def run():
-    adapter = choose_adapter()
-    conns = current_conns()
-    vpns = vpn_connections(conns)
-    gsms = gsm_connections(conns)
-    ssids = current_ssids(adapter)
-    other = other_actions()
-    sel = get_selection(ssids, vpns, gsms, other)
-    if sel in other:
-        # Parse other actions
-        if 'Networking' in sel:
-            toggle_networking(sel)
-        elif 'Wifi' in sel:
-            toggle_wifi(sel)
-        elif 'Launch' in sel:
-            launch_connection_editor()
-        sys.exit()
-    elif sel in ssids:
-        # Set ssid, security if selection is an SSID
-        ssid, security = [i for i in sel.strip().rsplit('  ')
-                          if i != ''][-3:-1]
-        security = security.strip()
-        ssid = ssid.strip()
-    elif sel.replace(":VPN", "").replace("**", "") in vpns:
-        # Select VPN connection (sel="pia_us_west:VPN")
-        ssid = sel.replace(":VPN", "").replace("**", "")
-    elif sel.replace(":GSM", "").replace("**", "") in gsms:
-        # Select GSM connection (sel="some_provider:GSM")
-        ssid = sel.replace(":GSM", "").replace("**", "")
-    else:
-        sys.exit()
-    # Decide if selection is existing connection or new
-    if ssid in [i.split(':')[0] for i in conns if i]:
-        toggle_existing(ssid)
-    else:
-        if security != '--':
-            pw = get_passphrase()
-        else:
-            pw = ""
-        set_new_connection(ssid, pw)
+    adapter = choose_adapter(client)
+
+    conns = client.get_connections()
+
+    vpns = list(filter(lambda c: c.is_type(NM.SETTING_VPN_SETTING_NAME), conns))
+    gsms = list(filter(lambda c: c.is_type(NM.SETTING_GSM_SETTING_NAME), conns))
+
+    aps = sorted(adapter.get_access_points(), key=lambda a: a.get_strength(), reverse=True)
+    other_actions = create_other_actions(client)
+
+    active = client.get_active_connections()
+    active_ap = adapter.get_active_access_point()
+
+    ap_actions = create_ap_actions(aps, active_ap, conns)
+    vpn_actions = create_vpn_actions(vpns, active)
+    gsm_actions = create_gsm_actions(gsms, active)
+    sel = get_selection(client, adapter, ap_actions, vpn_actions,
+                        gsm_actions, other_actions)
+    sel()
 
 
 if __name__ == '__main__':
     run()
+
+# vim: set et :

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -35,6 +35,7 @@ ENC = locale.getpreferredencoding()
 
 client = NM.Client.new(None)
 
+
 def dmenu_cmd(num_lines, prompt="Networks"):
     """Parse config.ini if it exists and add options to the dmenu command
 
@@ -85,7 +86,8 @@ def choose_adapter(client):
 
     """
     devices = client.get_devices()
-    devices = list(filter(lambda d: d.get_device_type() == NM.DeviceType.WIFI, devices))
+    devices = list(filter(lambda d: d.get_device_type() == NM.DeviceType.WIFI,
+                          devices))
     if len(devices) == 0:
         return None
     elif len(devices) == 1:
@@ -110,12 +112,14 @@ def create_other_actions(client):
     networking_action = "Disable" if networking_enabled else "Enable"
     wifi_enabled = client.wireless_get_enabled()
     wifi_action = "Disable" if wifi_enabled else "Enable"
-    return [Action("{} Wifi".format(wifi_action), toggle_wifi, not wifi_enabled),
-            Action("{} Networking".format(networking_action), toggle_networking, not networking_enabled),
-            Action("Launch Connection Manager", launch_connection_editor, None)]
+    return [Action("{} Wifi".format(wifi_action), toggle_wifi,
+                   not wifi_enabled),
+            Action("{} Networking".format(networking_action),
+                   toggle_networking, not networking_enabled),
+            Action("Launch Connection Manager", launch_connection_editor,
+                   None)]
 
 
-# copied from https://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/examples/python/gi/show-wifi-networks.py
 def ssid_to_utf8(ap):
     ssid = ap.get_ssid()
     if not ssid:
@@ -123,21 +127,20 @@ def ssid_to_utf8(ap):
     return NM.utils_ssid_to_utf8(ssid.get_data())
 
 
-# copied from https://cgit.freedesktop.org/NetworkManager/NetworkManager/tree/examples/python/gi/show-wifi-networks.py
 def ap_security(ap):
     flags = ap.get_flags()
     wpa_flags = ap.get_wpa_flags()
     rsn_flags = ap.get_rsn_flags()
     str = ""
     if ((flags & getattr(NM, '80211ApFlags').PRIVACY) and
-        (wpa_flags == 0) and (rsn_flags == 0)):
-        str = str  + " WEP"
+            (wpa_flags == 0) and (rsn_flags == 0)):
+        str = str + " WEP"
     if wpa_flags != 0:
         str = str + " WPA1"
     if rsn_flags != 0:
         str = str + " WPA2"
     if ((wpa_flags & getattr(NM, '80211ApSecurityFlags').KEY_MGMT_802_1X) or
-        (rsn_flags & getattr(NM, '80211ApSecurityFlags').KEY_MGMT_802_1X)):
+            (rsn_flags & getattr(NM, '80211ApSecurityFlags').KEY_MGMT_802_1X)):
         str = str + " 802.1X"
 
     # If there is no security use "--"
@@ -181,6 +184,7 @@ def process_ap(ap, existing):
             password = ""
         set_new_connection(ssid_to_utf8(ap), password)
 
+
 def process_vpn(vpn, activate):
     print("Processing VPN: %s" % vpn.get_id())
     if activate:
@@ -201,10 +205,14 @@ def create_ap_actions(aps, active_ap, existing_connections):
     max_len_sec = max([len(sec) for sec in secs])
     bars = [NM.utils_wifi_strength_bars(ap.get_strength()) for ap in aps]
     active_ap_bssid = active_ap.get_bssid() if active_ap is not None else ""
-    active_flags = ["**" if ap.get_bssid() == active_ap_bssid else "  " for ap in aps]
-    existing_conn_names = [conn.get_id() for conn in existing_connections]
-    is_existing = [len(ap.filter_connections(existing_connections)) > 0 for ap in aps]
-    return [Action("{} {:<{}s}  {:<{}s}  {}".format(active_flag, name, max_len_name, sec, max_len_sec, bar), process_ap, [ap, exists]) for ap, active_flag, name, sec, bar, exists in zip(aps, active_flags, names, secs, bars, is_existing)]
+    active_flags = ["**" if ap.get_bssid() == active_ap_bssid else
+                    "  " for ap in aps]
+    is_existing = [len(ap.filter_connections(existing_connections)) > 0
+                   for ap in aps]
+    return [Action("{} {:<{}s}  {:<{}s}  {}".format(active_flag, name,
+            max_len_name, sec, max_len_sec, bar), process_ap, [ap, exists])
+            for ap, active_flag, name, sec, bar, exists in zip(aps,
+            active_flags, names, secs, bars, is_existing)]
 
 
 def create_vpn_actions(vpns, active):
@@ -215,20 +223,26 @@ def create_vpn_actions(vpns, active):
         active_flag = "**" if is_active else "  "
         action_name = "{} {}:VPN".format(active_flag, vpn.get_id())
         if is_active:
-            active_connection = [a for a in active if a.get_id() == vpn.get_id()]
+            active_connection = [a for a in active
+                                 if a.get_id() == vpn.get_id()]
             assert len(active_connection) == 1
             active_connection = active_connection[0]
-            actions.append(Action(action_name, process_vpn, [active_connection, False]))
+            actions.append(Action(action_name, process_vpn,
+                                  [active_connection, False]))
         else:
             actions.append(Action(action_name, process_vpn, [vpn, True]))
     return actions
 
+
 # TODO: Test this
 def create_gsm_actions(gsms, active):
-    active_gsm_ids = [a.get_id() for a in active if a.get_connection().is_type(NM.SETTING_GSM_SETTING_NAME)]
-    active_flags = ["**" if (gsm.get_id() in active_vpn_ids) else "  " for gsm in gsms]
-    return [Action("{} {}:GSM".format(active_flag, gsm.get_id()), process_gsm, gsm) for active_flag, gsm in zip(active_flags, gsms)]
-
+    active_gsm_ids = [a.get_id() for a in active if
+                      a.get_connection().is_type(NM.SETTING_GSM_SETTING_NAME)]
+    active_flags = ["**" if (gsm.get_id() in active_gsm_ids) else
+                    "  " for gsm in gsms]
+    return [Action("{} {}:GSM".format(active_flag, gsm.get_id()),
+                   process_gsm, gsm) for active_flag, gsm in
+            zip(active_flags, gsms)]
 
 
 def get_selection(client, aps, vpns, gsms, others):
@@ -255,16 +269,17 @@ def get_selection(client, aps, vpns, gsms, others):
     inp += formated_others
 
     inp_bytes = "\n".join([str(i) for i in inp]).encode(ENC)
-    sel = Popen(dmenu_cmd(len(inp)),
-                stdin=PIPE,
-                stdout=PIPE, env=ENV).communicate(input=inp_bytes)[0].decode(ENC)
+    sel = Popen(dmenu_cmd(len(inp)), stdin=PIPE, stdout=PIPE,
+                env=ENV).communicate(input=inp_bytes)[0].decode(ENC)
 
     if not sel.rstrip():
         sys.exit()
 
-    action = list(filter(lambda x: str(x) == sel.rstrip(), aps + vpns + gsms + others))
-    assert len(action) == 1
+    action = list(filter(lambda x: str(x) == sel.rstrip(),
+                         aps + vpns + gsms + others))
+    assert len(action) == 1, "Selection was ambiguous: %s" % str(sel)
     return action[0]
+
 
 def toggle_existing(conn):
     """Get conn status, then toggle connection up or down if it's not
@@ -384,15 +399,18 @@ def run():
 
     if adapter:
         aps = sorted(adapter.get_access_points(),
-                     key=lambda a: a.get_strength(), reverse=True) active_ap = adapter.get_active_access_point()
+                     key=lambda a: a.get_strength(), reverse=True)
+        active_ap = adapter.get_active_access_point()
         ap_actions = create_ap_actions(aps, active_ap, conns)
     else:
         ap_actions = []
 
     active = client.get_active_connections()
 
-    vpns = list(filter(lambda c: c.is_type(NM.SETTING_VPN_SETTING_NAME), conns))
-    gsms = list(filter(lambda c: c.is_type(NM.SETTING_GSM_SETTING_NAME), conns))
+    vpns = list(filter(lambda c: c.is_type(NM.SETTING_VPN_SETTING_NAME),
+                       conns))
+    gsms = list(filter(lambda c: c.is_type(NM.SETTING_GSM_SETTING_NAME),
+                       conns))
 
     vpn_actions = create_vpn_actions(vpns, active)
     gsm_actions = create_gsm_actions(gsms, active)

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -34,6 +34,7 @@ ENV['LC_ALL'] = 'C'
 ENC = locale.getpreferredencoding()
 
 client = NM.Client.new(None)
+conns = client.get_connections()
 
 
 def dmenu_cmd(num_lines, prompt="Networks"):
@@ -116,8 +117,7 @@ def create_other_actions(client):
                    not wifi_enabled),
             Action("{} Networking".format(networking_action),
                    toggle_networking, not networking_enabled),
-            Action("Launch Connection Manager", launch_connection_editor,
-                   None)]
+            Action("Launch Connection Manager", launch_connection_editor)]
 
 
 def ssid_to_utf8(ap):
@@ -153,7 +153,7 @@ class Action(object):
     def __init__(self,
                  name,
                  f,
-                 args,
+                 args=None,
                  ):
         self.name = name
         self.f = f
@@ -174,8 +174,9 @@ class Action(object):
             self.f(*self.args)
 
 
-def process_ap(ap, existing):
-    if existing:
+def process_ap(ap):
+    is_existing = len(ap.filter_connections(conns)) > 0
+    if is_existing:
         toggle_existing(ssid_to_utf8(ap))
     else:
         if ap_security(ap) != "--":
@@ -198,21 +199,23 @@ def process_gsm(gsm):
     toggle_existing(gsm.get_id())
 
 
-def create_ap_actions(aps, active_ap, existing_connections):
+def create_ap_actions(aps, active_ap):
+    active_ap_bssid = active_ap.get_bssid() if active_ap is not None else ""
+
     names = [ssid_to_utf8(ap) for ap in aps]
     max_len_name = max([len(name) for name in names])
     secs = [ap_security(ap) for ap in aps]
     max_len_sec = max([len(sec) for sec in secs])
-    bars = [NM.utils_wifi_strength_bars(ap.get_strength()) for ap in aps]
-    active_ap_bssid = active_ap.get_bssid() if active_ap is not None else ""
-    active_flags = ["**" if ap.get_bssid() == active_ap_bssid else
-                    "  " for ap in aps]
-    is_existing = [len(ap.filter_connections(existing_connections)) > 0
-                   for ap in aps]
-    return [Action("{} {:<{}s}  {:<{}s}  {}".format(active_flag, name,
-            max_len_name, sec, max_len_sec, bar), process_ap, [ap, exists])
-            for ap, active_flag, name, sec, bar, exists in zip(aps,
-            active_flags, names, secs, bars, is_existing)]
+
+    ap_actions = []
+
+    for ap, name, sec in zip(aps, names, secs):
+        bars = NM.utils_wifi_strength_bars(ap.get_strength())
+        active_flag = "**" if ap.get_bssid() == active_ap_bssid else "  "
+        ap_actions.append(Action("{} {:<{}s}  {:<{}s}  {}".format(active_flag,
+                          name, max_len_name, sec, max_len_sec, bars),
+                          process_ap, ap))
+    return ap_actions
 
 
 def create_vpn_actions(vpns, active):
@@ -275,7 +278,7 @@ def get_selection(client, aps, vpns, gsms, others):
     if not sel.rstrip():
         sys.exit()
 
-    action = list(filter(lambda x: str(x) == sel.rstrip(),
+    action = list(filter(lambda x: str(x) == sel.rstrip("\n"),
                          aps + vpns + gsms + others))
     assert len(action) == 1, "Selection was ambiguous: %s" % str(sel)
     return action[0]
@@ -395,13 +398,12 @@ def set_new_connection(ssid, pw):
 
 def run():
     adapter = choose_adapter(client)
-    conns = client.get_connections()
 
     if adapter:
         aps = sorted(adapter.get_access_points(),
                      key=lambda a: a.get_strength(), reverse=True)
         active_ap = adapter.get_active_access_point()
-        ap_actions = create_ap_actions(aps, active_ap, conns)
+        ap_actions = create_ap_actions(aps, active_ap)
     else:
         ap_actions = []
 


### PR DESCRIPTION
With this rather thorough rewrite of nmcli-dmenu almost all calls to nmcli have been eliminated and been replaced with calls to the Python GI API (https://lazka.github.io/pgi-docs/#NM-1.0)

This requires PyGObjects (https://wiki.gnome.org/Projects/PyGObject), which should be widely available.
The upside to this is a decrease in execution time.
For me the execution time, before dmenu (or in my place rofi) is displayed is decreased from ~3.0 seconds to ~ 0.5 seconds. Which is quite noticeable.
Please be free to ask about the changes, I tried to make it behave in the same way as before.
I could not test the GSM part or multiple WiFi adapters!
