### PR TITLE
Add config option for number of lines to display

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -3,6 +3,7 @@ fn = -*-terminus-medium-*-*-*-16-*-*-*-*-*-*-*
 # dmenu_command = /usr/bin/dmenu
 # # Note that dmenu_command can contain arguments as well like `rofi -width 30`
 # # Rofi and dmenu are set to case insensitive by default `-i`
+# lines = number of lines to display, defaults to number of total network options
 # fn = font string
 # nb = normal background (name, #RGB, or #RRGGBB)
 # nf = normal foreground

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -54,6 +54,9 @@ def dmenu_cmd(num_lines, prompt="Networks"):
             dmenu_command = command[0]
             dmenu_args = command[1:]
             del args_dict["dmenu_command"]
+        if "lines" in args_dict:
+            num_lines = args_dict["lines"]
+            del args_dict["lines"]
         if "p" in args_dict and prompt == "Networks":
             prompt = args_dict["p"]
             del args_dict["p"]

--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -55,7 +55,8 @@ def dmenu_cmd(num_lines, prompt="Networks"):
             dmenu_args = command[1:]
             del args_dict["dmenu_command"]
         if "lines" in args_dict:
-            num_lines = args_dict["lines"]
+            if int(args_dict["lines"]) < num_lines:
+                num_lines = args_dict["lines"]
             del args_dict["lines"]
         if "p" in args_dict and prompt == "Networks":
             prompt = args_dict["p"]


### PR DESCRIPTION
Some people (myself) have more than a few dozen VPN connections available, as well as many seen network options. With so many options available, the default and unconfiguable number of lines makes dmenu stretch well beyond the size of the screen. This pull-request allows the user to configure an option in the config file, "lines", which changes the default "num_lines" variable if the configuration exists.