### PR TITLE
fix rofi not showing other options(Disable wifi, etc), dmenu still works

### DIFF
--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -120,7 +120,7 @@ def current_ssids(adapter):
     res = [i.rstrip().rsplit(' ', 1) for i in res]
     res = sorted(res, key=lambda x: int(x[1]), reverse=True)
     res = unique_ssid(res)
-    return [i[0].replace("'", "").rstrip() for i in res] + [""]
+    return [i[0].replace("'", "").rstrip() for i in res] + [" "]
 
 
 def unique_ssid(conns):
@@ -240,9 +240,9 @@ def get_selection(ssids, vpns, gsms, other):
     """
     active = get_active_connections()
     vpns = ["{}:VPN".format(i) for i in vpns]
-    vpns = mark_active(vpns, active) + [""] if vpns else []
+    vpns = mark_active(vpns, active) + [" "] if vpns else []
     gsms = ["{}:GSM".format(i) for i in gsms]
-    gsms = mark_active(gsms, active) + [""] if gsms else []
+    gsms = mark_active(gsms, active) + [" "] if gsms else []
     inp = ssids + vpns + gsms + other
     inp_bytes = "\n".join(inp).encode(ENC)
     sel = Popen(dmenu_cmd(len(inp)),


### PR DESCRIPTION
It seems that rofi doesn't accept "" character, but accecp " " character, thus after "" other options not showing. Replaceing "" with " " can fix this problem.

Before edition:
[https://s23.postimg.org/582fs3ajf/before.png](https://s23.postimg.org/582fs3ajf/before.png)
After edition:
[https://s29.postimg.org/qozs7lcmf/after.png](https://s29.postimg.org/qozs7lcmf/after.png)
dmenu still works:
[https://s24.postimg.org/kdd0zivqt/after_dmenu.png](https://s24.postimg.org/kdd0zivqt/after_dmenu.png)
