### PR TITLE
fix rofi become too large with -lines 0

### DIFF
--- a/nmcli_dmenu
+++ b/nmcli_dmenu
@@ -66,7 +66,12 @@ def dmenu_cmd(num_lines, prompt="Networks"):
         if "pinentry" in args_dict:
             del args_dict["pinentry"]
         extras = (["-" + str(k), str(v)] for (k, v) in args_dict.items())
-        res = [dmenu_command, str(num_lines), "-p", str(prompt)]
+        # rofi doesn't support 0 line, it requires at least 1 line
+        # see https://github.com/DaveDavenport/rofi/issues/252
+        if "rofi" in dmenu_command and num_lines == 0:
+            res = [dmenu_command, "1", "-p", str(prompt)]
+        else:
+            res = [dmenu_command, str(num_lines), "-p", str(prompt)]
         res.extend(dmenu_args)
         res += list(itertools.chain.from_iterable(extras))
         res[1:1] = lines.split()


### PR DESCRIPTION
rofi does not support single line mode yet
It will become very large with -lines 0 args
replace -lines 0 with -lines 1 is a workaround

screenshots: [https://s28.postimg.org/a9slws7gt/2017_01_14_23_42_22.png](https://s28.postimg.org/a9slws7gt/2017_01_14_23_42_22.png)
rofi related issue: [https://github.com/DaveDavenport/rofi/issues/252](https://github.com/DaveDavenport/rofi/issues/252)